### PR TITLE
Scheduler selection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - PYTHON_VERSION=2.7
     - MAIN_CMD="pytest pmda --pep8"
     - SETUP_CMD=""
-    - CONDA_DEPENDENCIES="mdanalysis dask joblib pytest-pep8"
+    - CONDA_DEPENDENCIES="mdanalysis mdanalysistests dask joblib pytest-pep8"
     - CONDA_CHANNELS='conda-forge'
     - CONDA_CHANNEL_PRIORITY=True
     - NUMPY_VERSION=stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ env:
     - PYTHON_VERSION=2.7
     - MAIN_CMD="pytest pmda --pep8"
     - SETUP_CMD=""
-    - CONDA_DEPENDENCIES="mdanalysis mdanalysistests dask joblib pytest-pep8"
-    - CONDA_CHANNELS='conda-forge'
+    # Don't need to install mdanalysis test since it is included in the development package
+    - CONDA_DEPENDENCIES="mdanalysis dask joblib pytest-pep8 mock"
+    # use kain88-de channel for development build of MDAnalysis
+    - CONDA_CHANNELS='conda-forge kain88-de '
     - CONDA_CHANNEL_PRIORITY=True
     - NUMPY_VERSION=stable
     - BUILD_CMD='python setup.py develop'
@@ -27,7 +29,7 @@ env:
     - GIT_CI_USER: TravisCI
     - GIT_CI_EMAIL: TravisCI@mdanalysis.org
     - MDA_DOCDIR: ${TRAVIS_BUILD_DIR}/build/sphinx/html
-    
+
 
   matrix:
     - NAME='standard'

--- a/pmda/parallel.py
+++ b/pmda/parallel.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import, division
 from six.moves import range
 
 import MDAnalysis as mda
+from dask import distributed, multiprocessing
 from dask.delayed import delayed
 from joblib import cpu_count
 import numpy as np
@@ -29,11 +30,13 @@ class Timing(object):
     """
     store various timeing results of obtained during a parallel analysis run
     """
-    def __init__(self, io, compute, total):
+
+    def __init__(self, io, compute, total, universe):
         self._io = io
         self._compute = compute
         self._total = total
         self._cumulate = np.sum(io) + np.sum(compute)
+        self._universe = universe
 
     @property
     def io(self):
@@ -59,13 +62,55 @@ class Timing(object):
         """
         return self._cumulate
 
+    @property
+    def universe(self):
+        """time to create a universe for each block"""
+        return self._universe
+
 
 class ParallelAnalysisBase(object):
     """Base class for defining parallel multi frame analysis
 
     The class it is designed as a template for creating multiframe analyses.
     This class will automatically take care of setting up the trajectory
-    reader for iterating, and it offers to show a progress meter.
+    reader for iterating in parallel.
+
+    To define a new Analysis, `ParallelAnalysisBase` needs to be subclassed
+    `_single_frame` and `_conclude`must be defined. It is also possible to
+    define `_prepare` for pre-processing. See the example below.
+
+    .. code-block:: python
+
+       class NewAnalysis(ParallelAnalysisBase):
+           def __init__(self, atomgroup, parameter):
+               self._ag = atomgroup
+               super(NewAnalysis, self).__init__(atomgroup.universe,
+                                                 self._ag)
+
+           def _single_frame(self, ts, agroups):
+               # REQUIRED
+               # called for every frame. ``ts`` contains the current time step
+               # and ``agroups`` a tuple of atomgroups that are updated to the
+               # current frame. Return result of `some_function` for a single
+               # frame
+               return some_function(agroups[0], self._parameter)
+
+           def _conclude(self):
+               # REQUIRED
+               # Called once iteration on the trajectory is finished. Results
+               # for each frame are stored in ``self._results`` in a per block
+               # basis. Here those results should be moved and reshaped into a
+               # sensible new variable.
+               self.results = np.hstack(self._results)
+               # Apply normalisation and averaging to results here if wanted.
+               self.results /= np.sum(self.results)
+
+    Afterwards the new analysis can be run like this.
+
+    .. code-block:: python
+
+       na = NewAnalysis(u.select_atoms('name CA'), 35).run()
+       print(na.result)
 
     """
 
@@ -99,62 +144,95 @@ class ParallelAnalysisBase(object):
         pass
 
     def _single_frame(self, ts, atomgroups):
-        """must return computed values"""
+        """must return computed values as a list. You can only read from member
+        variables stored in ``self``. Changing them during a run will result in
+        undefined behavior.
+
+        """
         raise NotImplementedError
 
-    def run(self, n_jobs=1, start=None, stop=None, step=None, get=None):
+    def run(self,
+            start=None,
+            stop=None,
+            step=None,
+            scheduler=None,
+            n_jobs=1,
+            n_blocks=None):
         """Perform the calculation
 
         Parameters
         ----------
-        n_jobs : int, optional
-            number of jobs to start, if `-1` use number of logical cpu cores
         start : int, optional
             start frame of analysis
         stop : int, optional
             stop frame of analysis
         step : int, optional
             number of frames to skip between each analysed frame
-        get : scheduler, optional
-            dask or distributed scheduler; by default, the dask
-            default is used
+        scheduler : dask scheduler, optional
+            Use dask scheduler, defaults to multiprocessing. This can be used
+            to spread work to a distributed scheduler
+        n_jobs : int, optional
+            number of jobs to start, if `-1` use number of logical cpu cores.
+            This argument will be ignored when the distributed scheduler is
+            used
+        n_blocks : int, optional
+            number of blocks to divide trajectory into. If ``None`` set equal
+            to n_jobs or number of available workers in scheduler.
+
         """
+        if scheduler is None:
+            scheduler = multiprocessing
+
         if n_jobs == -1:
             n_jobs = cpu_count()
+
+        if n_blocks is None:
+            if scheduler == multiprocessing:
+                n_blocks = n_jobs
+            elif isinstance(scheduler, distributed.Client):
+                n_blocks = len(scheduler.ncores())
+            else:
+                raise ValueError(
+                    "Couldn't guess ideal number of blocks from scheduler."
+                    "Please provide `n_blocks` in call to method.")
+
+        scheduler_kwargs = {'get': scheduler.get}
+        if scheduler == multiprocessing:
+            scheduler_kwargs['num_workers'] = n_jobs
 
         start, stop, step = self._trajectory.check_slice_indices(
             start, stop, step)
         n_frames = len(range(start, stop, step))
-
-        n_blocks = n_jobs
         bsize = int(np.ceil(n_frames / float(n_blocks)))
 
         with timeit() as total:
             blocks = []
             for b in range(n_blocks):
                 task = delayed(
-                    self.dask_helper, pure=False)(
-                        b * bsize + start,
-                        (b + 1) * bsize * step,
+                    self._dask_helper, pure=False)(
+                        b * bsize * step + start,
+                        min(stop, (b + 1) * bsize * step + start),
                         step,
                         self._indices,
                         self._top,
                         self._traj, )
                 blocks.append(task)
             blocks = delayed(blocks)
-            res = blocks.compute(get=get)
+            res = blocks.compute(**scheduler_kwargs)
             self._results = np.asarray([el[0] for el in res])
             self._conclude()
 
         self.timing = Timing(
             np.hstack([el[1] for el in res]),
-            np.hstack([el[2] for el in res]), total.elapsed)
+            np.hstack([el[2] for el in res]), total.elapsed,
+            np.array([el[3] for el in res]))
         return self
 
-    def dask_helper(self, start, stop, step, indices, top, traj):
+    def _dask_helper(self, start, stop, step, indices, top, traj):
         """helper function to actually setup dask graph"""
-        u = mda.Universe(top, traj)
-        agroups = [u.atoms[idx] for idx in indices]
+        with timeit() as b_universe:
+            u = mda.Universe(top, traj)
+            agroups = [u.atoms[idx] for idx in indices]
 
         res = []
         times_io = []
@@ -167,4 +245,5 @@ class ParallelAnalysisBase(object):
             times_io.append(b_io.elapsed)
             times_compute.append(b_compute.elapsed)
 
-        return np.asarray(res), np.asarray(times_io), np.asarray(times_compute)
+        return np.asarray(res), np.asarray(times_io), np.asarray(
+            times_compute), b_universe.elapsed

--- a/pmda/test/test_parallel.py
+++ b/pmda/test/test_parallel.py
@@ -1,0 +1,95 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+#
+# PMDA
+# Copyright (c) 2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+
+import numpy as np
+import pytest
+import MDAnalysis as mda
+from MDAnalysisTests.datafiles import DCD, PSF
+import joblib
+
+from dask import distributed, multiprocessing
+
+from pmda import parallel
+
+
+def test_timeing():
+    io = np.arange(5)
+    compute = np.arange(5) + 1
+    total = 5
+    universe = np.arange(2)
+    timing = parallel.Timing(io, compute, total, universe)
+
+    np.testing.assert_equal(timing.io, io)
+    np.testing.assert_equal(timing.compute, compute)
+    np.testing.assert_equal(timing.total, total)
+    np.testing.assert_equal(timing.universe, universe)
+    np.testing.assert_equal(timing.cumulate_time, np.sum(io) + np.sum(compute))
+
+
+class NoneAnalysis(parallel.ParallelAnalysisBase):
+    def __init__(self, atomgroup):
+        universe = atomgroup.universe
+        super(NoneAnalysis, self).__init__(universe, (atomgroup, ))
+
+    def _prepare(self):
+        pass
+
+    def _conclude(self):
+        self.res = np.hstack(self._results)
+
+    def _single_frame(self, ts, atomgroups):
+        return ts.frame
+
+
+@pytest.fixture
+def analysis():
+    u = mda.Universe(PSF, DCD)
+    ana = NoneAnalysis(u.atoms)
+    return ana
+
+
+def test_wrong_scheduler(analysis):
+    with pytest.raises(ValueError):
+        analysis.run(scheduler=2)
+
+
+@pytest.mark.parametrize('n_jobs', (1, 2))
+def test_all_frames(analysis, n_jobs):
+    analysis.run(n_jobs=n_jobs)
+    u = mda.Universe(analysis._top, analysis._traj)
+    assert len(analysis.res) == u.trajectory.n_frames
+
+
+@pytest.mark.parametrize('n_jobs', (1, 2))
+def test_sub_frames(analysis, n_jobs):
+    analysis.run(start=10, stop=50, step=10, n_jobs=n_jobs)
+    np.testing.assert_almost_equal(analysis.res, [10, 20, 30, 40])
+
+
+@pytest.fixture(scope='session', params=('distributed', 'multiprocessing'))
+def scheduler(request):
+    if request.param == 'distributed':
+        return distributed.Client()
+    else:
+        return multiprocessing
+
+
+def test_scheduler(analysis, scheduler):
+    analysis.run(scheduler=scheduler)
+
+
+@pytest.mark.parametrize('n_blocks', np.arange(1, 11))
+def test_nblocks(analysis, n_blocks):
+    analysis.run(n_blocks=n_blocks)
+    assert len(analysis._results) == n_blocks
+
+
+def test_guess_nblocks(analysis):
+    analysis.run(n_jobs=-1)
+    assert len(analysis._results) == joblib.cpu_count()

--- a/pmda/test/test_util.py
+++ b/pmda/test/test_util.py
@@ -1,3 +1,11 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+#
+# PMDA
+# Copyright (c) 2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
 import time
 from numpy.testing import assert_almost_equal
 

--- a/pmda/test/test_util.py
+++ b/pmda/test/test_util.py
@@ -16,4 +16,4 @@ def test_timeit():
     with timeit() as timer:
         time.sleep(1)
 
-    assert_almost_equal(timer.elapsed, 1, decimal=3)
+    assert_almost_equal(timer.elapsed, 1, decimal=2)

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,5 @@ setup(
     ],
     tests_require=[
         'pytest',
+        'MDAnalysisTests>=0.16',  # keep
     ], )


### PR DESCRIPTION
allow a more intelligent scheduler selection. By default we are now using `dask.multiprocessing`. The run method can now also be used to split the number of jobs and blocks separately. 

**TODO**:
 -  [x] guess number of blocks given a distributed scheduler
 -  [x] tests