### PR TITLE
added attr_lock to parallelanalysisbase

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,5 @@ Chronological list of authors
 
  2018
   - Shujie Fan
+  - Richard J Gowers
+

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,13 +13,14 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-xx/xx/18 VOD555
+xx/xx/18 VOD555, richardjgowers
 
   * 0.2.0
 
 Enhancements
   * add add timing for _conclude and _prepare (Issue #49)
   * add parallel particle-particle RDF calculation module pmda.rdf (Issue #41)
+  * add readonly_attributes context manager to ParallelAnalysisBase
 
 
 06/07/18 orbeckst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'PMDA'
-author = u'Max Linke, Shujie Fan, Oliver Beckstein'
+author = u'Max Linke, Shujie Fan, Richard J. Gowers, Oliver Beckstein'
 copyright = u'2018, ' + author
 
 

--- a/pmda/test/test_parallel.py
+++ b/pmda/test/test_parallel.py
@@ -111,3 +111,22 @@ def test_nblocks(analysis, n_blocks):
 def test_guess_nblocks(analysis):
     analysis.run(n_jobs=-1)
     assert len(analysis._results) == joblib.cpu_count()
+
+
+def test_attrlock():
+    u = mda.Universe(PSF, DCD)
+    pab = parallel.ParallelAnalysisBase(u, (u.atoms,))
+
+    # Should initially be allowed to set attributes
+    pab.thing1 = 24
+    assert pab.thing1 == 24
+    # Apply lock
+    with pab.readonly_attributes():
+        # Reading should still work
+        assert pab.thing1 == 24
+        # Setting should fail
+        with pytest.raises(AttributeError):
+            pab.thing2 = 100
+    # Outside of lock context setting should again work
+    pab.thing2 = 100
+    assert pab.thing2 == 100


### PR DESCRIPTION
In #46 problems were encountered partly because in `_single_frame` the class was being modified.

This adds some special behaviour to the ParallelAnalysisBase setattr which allows the setting of attributes to be turned off.

I'm still reading through the package, but I think you could use this in `run`, something like:

```python
def run():
    self._prepare()
    # done preparing, lock everything up
    self._attr_lock = True
    # parallel magic

    # returned from parallel land, restore class to normal behaviour
    self._attr_lock = False
    self._conclude()