### PR TITLE
replace res with two kinds of output, accumulator and timeseries

### DIFF
--- a/pmda/contacts.py
+++ b/pmda/contacts.py
@@ -285,10 +285,6 @@ class Contacts(ParallelAnalysisBase):
             y = y[0]
         return y
 
-    def _reduce(self, res, result_single_frame):
-        res.append(result_single_frame)
-        return res
-
     def _conclude(self):
         self.timeseries = np.hstack(self._results)
 
@@ -337,4 +333,3 @@ def q1q2(atomgroup, radius=4.5):
         radius=radius,
         method=radius_cut_q,
         kwargs={'radius': radius})
-

--- a/pmda/contacts.py
+++ b/pmda/contacts.py
@@ -283,10 +283,14 @@ class Contacts(ParallelAnalysisBase):
 
         if len(y) == 1:
             y = y[0]
-        return {'timeseries': y}
+        return y
+
+    def _reduce(self, res, result_single_frame):
+        res.append(result_single_frame)
+        return res
 
     def _conclude(self):
-        self.timeseries = np.hstack(self._results['timeseries'])
+        self.timeseries = np.hstack(self._results)
 
 
 def q1q2(atomgroup, radius=4.5):
@@ -333,3 +337,4 @@ def q1q2(atomgroup, radius=4.5):
         radius=radius,
         method=radius_cut_q,
         kwargs={'radius': radius})
+

--- a/pmda/contacts.py
+++ b/pmda/contacts.py
@@ -283,10 +283,10 @@ class Contacts(ParallelAnalysisBase):
 
         if len(y) == 1:
             y = y[0]
-        return y
+        return {'timeseries': y}
 
     def _conclude(self):
-        self.timeseries = np.hstack(self._results)
+        self.timeseries = np.hstack(self._results['timeseries'])
 
 
 def q1q2(atomgroup, radius=4.5):

--- a/pmda/parallel.py
+++ b/pmda/parallel.py
@@ -87,14 +87,15 @@ class ParallelAnalysisBase(object):
     The class it is designed as a template for creating multiframe analyses.
     This class will automatically take care of setting up the trajectory
     reader for iterating in parallel.
-    
-    To parallelize the analysis ``ParallelAnalysisBase`` separates the 
-    trajectory into work blocks containing multiple frames. The number of blocks 
-    is equal to the number of available cores or dask workers. This minimizes 
-    the number of python processes that are started during a calculation. 
-    Accumulation of frames within a block happens in the `self._reduce` function.
-    A consequence when using dask is that adding additional workers during a 
-    computation will not result in an reduction of run-time. 
+
+    To parallelize the analysis ``ParallelAnalysisBase`` separates the
+    trajectory into work blocks containing multiple frames. The number of
+    blocks is equal to the number of available cores or dask workers. This
+    minimizes the number of python processes that are started during a
+    calculation. Accumulation of frames within a block happens in the
+    `self._reduce` function. A consequence when using dask is that adding
+    additional workers during a computation will not result in an reduction
+    of run-time.
 
 
     To define a new Analysis,
@@ -104,7 +105,7 @@ class ParallelAnalysisBase(object):
     :meth:`~pmda.parallel.ParallelAnalysisBase._conclude` must be
     defined. It is also possible to define
     :meth:`~~pmda.parallel.ParallelAnalysisBase._prepare` for
-    pre-processing and :meth:`~~pmda.parallel.ParallelAnalysisBase._reduce` 
+    pre-processing and :meth:`~~pmda.parallel.ParallelAnalysisBase._reduce`
     for custom reduce operation on the work blocks. See the example below.
 
     .. code-block:: python

--- a/pmda/parallel.py
+++ b/pmda/parallel.py
@@ -121,7 +121,32 @@ class ParallelAnalysisBase(object):
                # sensible new variable.
                self.results = np.hstack(self._results)
                # Apply normalisation and averaging to results here if wanted.
-               self.results /= np.sum(self.results)
+               self.results /= np.sum(self.results
+
+           @staticmethod
+           def _reduce(res, result_single_frame):
+               # NOT REQUIRED
+               # Called for every frame. ``res`` contains all the results
+               # before current time step, and ``result_single_frame`` is
+               # the result of self._single_frame for the current time step.
+               # Here the single frame result is `added` to ``res``. Return
+               # the new ``res``.
+               # One can define the way to `add` result for a single frame.
+               # The default is to generate a python list, and append the
+               # result for a single frame to the list. We call this kind of
+               # ``res`` `timeseries`.
+               res.append(result_single_frame)
+               # If one wants ``self._reduce`` to sum up results for each
+               # single frame, there's one example in `rdf.py`. We call it
+               # `accumulator`.
+               if res == []:
+               # Convert res from an empty list to a numpy array which has the
+               # same shape as the single frame result
+                   res = result_single_frame
+               else:
+               # Add two numpy arrays
+                   res += result_single_frame
+               return res
 
     Afterwards the new analysis can be run like this.
 

--- a/pmda/parallel.py
+++ b/pmda/parallel.py
@@ -299,14 +299,14 @@ class ParallelAnalysisBase(object):
                     blocks.append(task)
                 blocks = delayed(blocks)
                 res = blocks.compute(**scheduler_kwargs)
-            self._results = np.asarray([el[0] for el in res])
+            self._results = {'timeseries': np.asarray([el[0] for el in res]), 'accumulator': np.asarray([el[1] for el in res])}
             with timeit() as conclude:
                 self._conclude()
 
         self.timing = Timing(
-            np.hstack([el[1] for el in res]),
-            np.hstack([el[2] for el in res]), total.elapsed,
-            np.array([el[3] for el in res]), time_prepare, conclude.elapsed)
+            np.hstack([el[2] for el in res]),
+            np.hstack([el[3] for el in res]), total.elapsed,
+            np.array([el[4] for el in res]), time_prepare, conclude.elapsed)
         return self
 
     def _dask_helper(self, start, stop, step, indices, top, traj):
@@ -315,16 +315,24 @@ class ParallelAnalysisBase(object):
             u = mda.Universe(top, traj)
             agroups = [u.atoms[idx] for idx in indices]
 
-        res = []
+        t_ser = []
+        accum = []
         times_io = []
         times_compute = []
         for i in range(start, stop, step):
             with timeit() as b_io:
                 ts = u.trajectory[i]
             with timeit() as b_compute:
-                res.append(self._single_frame(ts, agroups))
+                res_sf = self._single_frame(ts, agroups)
+                if 'accumulator' in res_sf:
+                    if accum == []:
+                        accum = res_sf['accumulator']
+                    else:
+                        accum += res_sf['accumulator']
+                if 'timeseries' in res_sf:
+                    t_ser.append(res_sf['timeseries']) 
             times_io.append(b_io.elapsed)
             times_compute.append(b_compute.elapsed)
 
-        return np.asarray(res), np.asarray(times_io), np.asarray(
-            times_compute), b_universe.elapsed
+        return np.asarray(t_ser), accum, np.asarray(times_io), np.asarray(
+            times_compute), b_universe.elapsed, 

--- a/pmda/parallel.py
+++ b/pmda/parallel.py
@@ -329,7 +329,8 @@ class ParallelAnalysisBase(object):
         return np.asarray(res), np.asarray(times_io), np.asarray(
             times_compute), b_universe.elapsed
 
-    def _reduce(self, res, result_single_frame):
+    @staticmethod
+    def _reduce(res, result_single_frame):
         """ 'append' action for a time series"""
         res.append(result_single_frame)
         return res

--- a/pmda/rdf.py
+++ b/pmda/rdf.py
@@ -136,7 +136,7 @@ class InterRDF(ParallelAnalysisBase):
         count = np.histogram(d, **self.rdf_settings)[0]
         volume = u.trajectory.ts.volume
 
-        return np.array([count, np.array(volume, dtype = np.float64)])
+        return np.array([count, np.array(volume, dtype=np.float64)])
 
     def _conclude(self, ):
         self.count = np.sum(self._results[:, 0])
@@ -161,7 +161,8 @@ class InterRDF(ParallelAnalysisBase):
         rdf = self.count / (density * vol * self.nf)
         self.rdf = rdf
 
-    def _reduce(self, res, result_single_frame):
+    @staticmethod
+    def _reduce(res, result_single_frame):
         """ 'add' action for an accumulator"""
         if res == []:
             # Convert res from an empty list to a numpy array

--- a/pmda/rdf.py
+++ b/pmda/rdf.py
@@ -8,19 +8,21 @@
 # Released under the GNU Public Licence, v2 or any higher version
 """
 Radial Distribution Functions --- :mod:`pmda.rdf`
-================================================================
+=================================================
 
 This module contains parallel versions of analysis tasks in
 :mod:`MDAnalysis.analysis.rdf`.
 
-Classes:
--------
-
-.. autoclass:: InterRDF
-
 See Also
 --------
 MDAnalysis.analysis.rdf
+
+
+Classes
+-------
+.. autoclass:: InterRDF
+   :members:
+   :inherited-members:
 
 """
 
@@ -28,10 +30,8 @@ from __future__ import absolute_import, division
 
 import numpy as np
 
-from MDAnalysis.lib import distances
 from MDAnalysis.lib.distances import distance_array
 from MDAnalysis.lib.util import blocks_of
-
 
 from .parallel import ParallelAnalysisBase
 
@@ -39,14 +39,22 @@ from .parallel import ParallelAnalysisBase
 class InterRDF(ParallelAnalysisBase):
     """Intermolecular pair distribution function
 
-    InterRDF(g1, g2, nbins=75, range=(0.0, 15.0))
+    Attributes
+    ----------
+    bins : array
+         The distance :math:`r` at which the distribution
+         function :math:`g(r)` is determined; these are calculated as
+         the centers of the bins that were used for histogramming.
+    rdf : array
+         The value of the pair distribution function :math:`g(r)` at
+         :math:`r`.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     g1 : AtomGroup
-      First AtomGroup
+          First AtomGroup
     g2 : AtomGroup
-      Second AtomGroup
+          Second AtomGroup
     nbins : int (optional)
           Number of bins in the histogram [75]
     range : tuple or list (optional)
@@ -54,13 +62,6 @@ class InterRDF(ParallelAnalysisBase):
     exclusion_block : tuple (optional)
           A tuple representing the tile to exclude from the distance
           array. [None]
-    start : int (optional)
-          The frame to start at (default is first)
-    stop : int (optional)
-          The frame to end at (default is last)
-    step : int (optional)
-          The step size through the trajectory in frames (default is
-          every frame)
 
     Example
     -------
@@ -78,6 +79,11 @@ class InterRDF(ParallelAnalysisBase):
     The `exclusion_block` keyword allows the masking of pairs from
     within the same molecule.  For example, if there are 7 of each
     atom in each molecule, the exclusion mask `(7, 7)` can be used.
+
+    See Also
+    --------
+    MDAnalysis.analysis.rdf.InterRDF
+
 
     .. versionadded:: 0.2.0
 
@@ -111,34 +117,30 @@ class InterRDF(ParallelAnalysisBase):
 
         # Need to know average volume
         self.volume = 0.0
-        self._maxrange = self.rdf_settings['range'][1]
 
     def _single_frame(self, ts, atomgroups):
         g1, g2 = atomgroups
         u = g1.universe
-        dist = distance_array(g1.positions, g2.positions,
+        d = distance_array(g1.positions, g2.positions,
                            box=u.dimensions)
         # If provided exclusions, create a mask of _result which
         # lets us take these out
         exclusion_mask = None
         if self._exclusion_block is not None:
-            exclusion_mask = blocks_of(dist, *self._exclusion_block)
+            exclusion_mask = blocks_of(d, *self._exclusion_block)
             maxrange = self.rdf_settings['range'][1] + 1.0
         # Maybe exclude same molecule distances
         if exclusion_mask is not None:
             exclusion_mask[:] = maxrange
-
         count = []
-        count = np.histogram(dist, **self.rdf_settings)[0]
+        count = np.histogram(d, **self.rdf_settings)[0]
         volume = u.trajectory.ts.volume
 
-        return {'accumulator': np.array([count, np.array(volume, dtype = np.float64)])}
+        return np.array([count, np.array(volume, dtype = np.float64)])
 
     def _conclude(self, ):
-        for data in self._results['accumulator']:
-            self.count += data[0]
-            self.volume += data[1]
-
+        self.count = np.sum(self._results[:, 0])
+        self.volume = np.sum(self._results[:, 1])
         # Number of each selection
         N = self.nA * self.nB
 
@@ -158,3 +160,14 @@ class InterRDF(ParallelAnalysisBase):
 
         rdf = self.count / (density * vol * self.nf)
         self.rdf = rdf
+
+    def _reduce(self, res, result_single_frame):
+        """ 'add' action for an accumulator"""
+        if res == []:
+            # Convert res from an empty list to a numpy array
+            # which has the same shape as the single frame result
+            res = result_single_frame
+        else:
+            # Add two numpy arrays
+            res += result_single_frame
+        return res

--- a/pmda/test/test_parallel.py
+++ b/pmda/test/test_parallel.py
@@ -130,3 +130,13 @@ def test_attrlock():
     # Outside of lock context setting should again work
     pab.thing2 = 100
     assert pab.thing2 == 100
+
+
+def test_reduce():
+    res = []
+    u = mda.Universe(PSF, DCD)
+    ana = NoneAnalysis(u.atoms)
+    res = ana._reduce(res, [1])
+    res = ana._reduce(res, [1])
+    # Should see res become a list with 2 elements.
+    assert res == [[1], [1]]

--- a/pmda/test/test_rdf.py
+++ b/pmda/test/test_rdf.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import
 import pytest
 
 import MDAnalysis as mda
+import numpy as np
 from pmda.rdf import InterRDF
 from MDAnalysis.analysis import rdf
 
@@ -90,9 +91,21 @@ def test_same_result(sels):
     s1, s2 = sels
     nrdf = rdf.InterRDF(s1, s2).run()
     prdf = InterRDF(s1, s2).run()
-    assert_almost_equal(nrdf.rdf, prdf.rdf)
     assert_almost_equal(nrdf.count, prdf.count)
+    assert_almost_equal(nrdf.rdf, prdf.rdf)
 
+
+def test_reduce(sels):
+    # should see numpy.array addtion
+    s1, s2 = sels
+    rdf = InterRDF(s1, s2)
+    res = []
+    single_frame = np.array([np.array([1,2]), np.array([3])])
+    res = rdf._reduce(res, single_frame)
+    res = rdf._reduce(res, single_frame)
+    assert_almost_equal(res[0], np.array([2,4]))
+    assert_almost_equal(res[1], np.array([6]))
+       
 
 @pytest.mark.parametrize('exclusion_block, value', [
             (None, 577),

--- a/pmda/test/test_rdf.py
+++ b/pmda/test/test_rdf.py
@@ -100,12 +100,12 @@ def test_reduce(sels):
     s1, s2 = sels
     rdf = InterRDF(s1, s2)
     res = []
-    single_frame = np.array([np.array([1,2]), np.array([3])])
+    single_frame = np.array([np.array([1, 2]), np.array([3])])
     res = rdf._reduce(res, single_frame)
     res = rdf._reduce(res, single_frame)
-    assert_almost_equal(res[0], np.array([2,4]))
+    assert_almost_equal(res[0], np.array([2, 4]))
     assert_almost_equal(res[1], np.array([6]))
-       
+
 
 @pytest.mark.parametrize('exclusion_block, value', [
             (None, 577),


### PR DESCRIPTION
Changes made in this Pull Request:
 - Replace res with two kinds of output: accumulator and timeseries.
timeseries is the same as the old res, which just appends the result from each step. 
The other one, accumulator, accumulates the results so that we can reduce the size of the results of each parallelled task for function such as rdf.

The example for timeseries is contact.py, and the one for accumulator is rdf. 


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
