### PR TITLE
store block information

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,11 @@ The rules for this file:
 
   * 0.2.2
 
+Enhancements
+
+  * add timer for block-IO and block-compute
+  * store block information in `_block` attribute (Issue #89)
+
 Fixes
   * default _conclude() in pmda.custom.AnalysisFromFunction fails with
     scalar per frame data (Issue #87)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,10 +15,9 @@ The rules for this file:
 ------------------------------------------------------------------------------
 2019/**/** VOD555
 
-  * 0.2.2
+  * 0.3.0
 
 Enhancements
-
   * add timer for block-IO and block-compute
   * store block information in `_block` attribute (Issue #89)
 

--- a/pmda/parallel.py
+++ b/pmda/parallel.py
@@ -434,10 +434,10 @@ class ParallelAnalysisBase(object):
             times_io.append(b_io.elapsed)
             times_compute.append(b_compute.elapsed)
 
+        # calculate io and compute time per block
         return np.asarray(res), np.asarray(times_io), np.asarray(
-            times_compute), b_universe.elapsed, wait_end,
-            # calculate io and compute time per block
-            np.sum(times_io), np.sum(times_compute)
+            times_compute), b_universe.elapsed, wait_end, np.sum(
+            times_io), np.sum(times_compute)
 
     @staticmethod
     def _reduce(res, result_single_frame):

--- a/pmda/parallel.py
+++ b/pmda/parallel.py
@@ -361,7 +361,9 @@ class ParallelAnalysisBase(object):
         slices = make_balanced_slices(n_frames, n_blocks,
                                       start=start, stop=stop, step=step)
 
+        # record total time
         with timeit() as total:
+            # record prepare time
             with timeit() as prepare:
                 self._prepare()
             time_prepare = prepare.elapsed
@@ -376,6 +378,7 @@ class ParallelAnalysisBase(object):
                              self._top,
                              self._traj, )
                     blocks.append(task)
+                    # save the frame numbers for each block
                     _blocks.append(range(bslice.start,
                                    bslice.stop, bslice.step))
                 blocks = delayed(blocks)
@@ -387,11 +390,13 @@ class ParallelAnalysisBase(object):
             if len(res) == 0:
                 # everything else wants list of block tuples
                 res = [([], [], [], 0, wait_start, 0, 0)]
+            # record conclude time
             with timeit() as conclude:
                 self._results = np.asarray([el[0] for el in res])
                 self._conclude()
+                # save the frame numbers for all blocks
                 self._blocks = _blocks
-
+        # put all time information into the timing object
         self.timing = Timing(
             np.hstack([el[1] for el in res]),
             np.hstack([el[2] for el in res]), total.elapsed,
@@ -407,6 +412,7 @@ class ParallelAnalysisBase(object):
         """helper function to actually setup dask graph"""
         # wait_end needs to be first line for accurate timing
         wait_end = time.time()
+        # record time to generate universe and atom groups
         with timeit() as b_universe:
             u = mda.Universe(top, traj)
             agroups = [u.atoms[idx] for idx in indices]
@@ -417,18 +423,21 @@ class ParallelAnalysisBase(object):
         # NOTE: bslice.stop cannot be None! Always make sure
         #       that it comes from  _trajectory.check_slice_indices()!
         for i in range(bslice.start, bslice.stop, bslice.step):
+            # record io time per frame
             with timeit() as b_io:
                 # explicit instead of 'for ts in u.trajectory[bslice]'
                 # so that we can get accurate timing.
                 ts = u.trajectory[i]
+            # record compute time per frame
             with timeit() as b_compute:
                 res = self._reduce(res, self._single_frame(ts, agroups))
             times_io.append(b_io.elapsed)
             times_compute.append(b_compute.elapsed)
 
         return np.asarray(res), np.asarray(times_io), np.asarray(
-            times_compute), b_universe.elapsed, wait_end, np.sum(
-            times_io), np.sum(times_compute)
+            times_compute), b_universe.elapsed, wait_end,
+            # calculate io and compute time per block
+            np.sum(times_io), np.sum(times_compute)
 
     @staticmethod
     def _reduce(res, result_single_frame):

--- a/pmda/parallel.py
+++ b/pmda/parallel.py
@@ -376,7 +376,8 @@ class ParallelAnalysisBase(object):
                              self._top,
                              self._traj, )
                     blocks.append(task)
-                    _blocks.append(range(bslice.start, bslice.stop, bslice.step))
+                    _blocks.append(range(bslice.start,
+                                    bslice.stop, bslice.step))
                 blocks = delayed(blocks)
 
                 # record the time when scheduler starts working

--- a/pmda/parallel.py
+++ b/pmda/parallel.py
@@ -348,8 +348,8 @@ class ParallelAnalysisBase(object):
         if scheduler == 'multiprocessing':
             scheduler_kwargs['num_workers'] = n_jobs
 
-        start, stop, step = self._trajectory.check_slice_indices(
-            start, stop, step)
+        start, stop, step = self._trajectory.check_slice_indices(start,
+                                                                 stop, step)
         n_frames = len(range(start, stop, step))
 
         if n_frames == 0:
@@ -377,7 +377,7 @@ class ParallelAnalysisBase(object):
                              self._traj, )
                     blocks.append(task)
                     _blocks.append(range(bslice.start,
-                                    bslice.stop, bslice.step))
+                                   bslice.stop, bslice.step))
                 blocks = delayed(blocks)
 
                 # record the time when scheduler starts working

--- a/pmda/parallel.py
+++ b/pmda/parallel.py
@@ -366,6 +366,7 @@ class ParallelAnalysisBase(object):
                 self._prepare()
             time_prepare = prepare.elapsed
             blocks = []
+            _blocks = []
             with self.readonly_attributes():
                 for bslice in slices:
                     task = delayed(
@@ -375,6 +376,7 @@ class ParallelAnalysisBase(object):
                              self._top,
                              self._traj, )
                     blocks.append(task)
+                    _blocks.append(range(bslice.start, bslice.stop, bslice.step))
                 blocks = delayed(blocks)
 
                 # record the time when scheduler starts working
@@ -387,6 +389,7 @@ class ParallelAnalysisBase(object):
             with timeit() as conclude:
                 self._results = np.asarray([el[0] for el in res])
                 self._conclude()
+                self._blocks = _blocks
 
         self.timing = Timing(
             np.hstack([el[1] for el in res]),

--- a/pmda/parallel.py
+++ b/pmda/parallel.py
@@ -424,7 +424,7 @@ class ParallelAnalysisBase(object):
 
         return np.asarray(res), np.asarray(times_io), np.asarray(
             times_compute), b_universe.elapsed, wait_end, np.sum(
-            np.asarray(times_io)), np.sum(np.asarray(times_compute))
+            times_io), np.sum(times_compute)
 
     @staticmethod
     def _reduce(res, result_single_frame):

--- a/pmda/parallel.py
+++ b/pmda/parallel.py
@@ -36,9 +36,12 @@ class Timing(object):
     """
 
     def __init__(self, io, compute, total, universe, prepare,
-                 conclude, wait=None):
+                 conclude, wait=None, io_block=None,
+                 compute_block=None):
         self._io = io
+        self._io_block = io_block
         self._compute = compute
+        self._compute_block = compute_block
         self._total = total
         self._cumulate = np.sum(io) + np.sum(compute)
         self._universe = universe
@@ -52,9 +55,19 @@ class Timing(object):
         return self._io
 
     @property
+    def io_block(self):
+        """io time per block"""
+        return self._io_block
+
+    @property
     def compute(self):
         """compute time per frame"""
         return self._compute
+
+    @property
+    def compute_block(self):
+        """compute time per block"""
+        return self._compute_block
 
     @property
     def total(self):
@@ -370,7 +383,7 @@ class ParallelAnalysisBase(object):
             # hack to handle n_frames == 0 in this framework
             if len(res) == 0:
                 # everything else wants list of block tuples
-                res = [([], [], [], 0, 0)]
+                res = [([], [], [], 0, wait_start, 0, 0)]
             with timeit() as conclude:
                 self._results = np.asarray([el[0] for el in res])
                 self._conclude()
@@ -381,7 +394,9 @@ class ParallelAnalysisBase(object):
             np.array([el[3] for el in res]), time_prepare,
             conclude.elapsed,
             # waiting time = wait_end - wait_start
-            np.array([el[4]-wait_start for el in res]))
+            np.array([el[4]-wait_start for el in res]),
+            np.array([el[5] for el in res]),
+            np.array([el[6] for el in res]))
         return self
 
     def _dask_helper(self, bslice, indices, top, traj):
@@ -408,7 +423,8 @@ class ParallelAnalysisBase(object):
             times_compute.append(b_compute.elapsed)
 
         return np.asarray(res), np.asarray(times_io), np.asarray(
-            times_compute), b_universe.elapsed, wait_end
+            times_compute), b_universe.elapsed, wait_end, np.sum(
+            np.asarray(times_io)), np.sum(np.asarray(times_compute))
 
     @staticmethod
     def _reduce(res, result_single_frame):

--- a/pmda/test/test_custom.py
+++ b/pmda/test/test_custom.py
@@ -31,9 +31,14 @@ def custom_function_scalar(ag):
     return ag.radius_of_gyration()
 
 
+def custom_function_tensor(ag):
+    return ag.moment_of_inertia()
+
+
 @pytest.mark.parametrize('custom_function', [
     custom_function_vector,
     custom_function_scalar,
+    custom_function_tensor,
     ])
 @pytest.mark.parametrize('step', [None, 1, 2, 3, 7, 33])
 def test_AnalysisFromFunction(scheduler, universe, custom_function, step):
@@ -78,6 +83,7 @@ def test_AnalysisFromFunction_otherAgs(universe, step=2):
 @pytest.mark.parametrize('custom_function', [
     custom_function_vector,
     custom_function_scalar,
+    custom_function_tensor,
     ])
 def test_analysis_class(universe, custom_function, step=2):
     ana_class = custom.analysis_class(custom_function)

--- a/pmda/test/test_parallel.py
+++ b/pmda/test/test_parallel.py
@@ -27,9 +27,12 @@ def test_timeing():
     prepare = 3
     conclude = 6
     wait = 12
+    io_block = np.sum(io)
+    compute_block = np.sum(compute)
 
     timing = parallel.Timing(io, compute, total,
-                             universe, prepare, conclude, wait)
+                             universe, prepare, conclude, wait,
+                             io_block, compute_block,)
 
     np.testing.assert_equal(timing.io, io)
     np.testing.assert_equal(timing.compute, compute)
@@ -39,6 +42,8 @@ def test_timeing():
     np.testing.assert_equal(timing.prepare, prepare)
     np.testing.assert_equal(timing.conclude, conclude)
     np.testing.assert_equal(timing.wait, wait)
+    np.testing.assert_equal(timing.io_block, io_block)
+    np.testing.assert_equal(timing.compute_block, compute_block)
 
 
 class NoneAnalysis(parallel.ParallelAnalysisBase):
@@ -86,6 +91,9 @@ def test_no_frames(analysis, n_jobs):
     np.testing.assert_equal(analysis.res, [])
     np.testing.assert_equal(analysis.timing.compute, [])
     np.testing.assert_equal(analysis.timing.io, [])
+    np.testing.assert_equal(analysis.timing.io_block, [0])
+    np.testing.assert_equal(analysis.timing.compute_block, [0])
+    np.testing.assert_equal(analysis.timing.wait, [0])
     assert analysis.timing.universe == 0
 
 


### PR DESCRIPTION
Fixes #89

Changes made in this Pull Request:
 - Store the block information in `parallel.run` function.
 - The information is stored in self._blocks.
 - Add tests for storing block infromation.

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
