### PR TITLE
DensityAnalysis and RMSF start/stop/step Issue Fix 

### DIFF
--- a/pmda/density.py
+++ b/pmda/density.py
@@ -304,7 +304,7 @@ class DensityAnalysis(ParallelAnalysisBase):
         metadata['psf'] = self._atomgroup.universe.filename
         metadata['dcd'] = self._trajectory.filename
         metadata['atomselection'] = self._atomselection
-        # metadata['n_frames'] = self._n_frames
+        metadata['n_frames'] = self.n_frames
         metadata['totaltime'] = self._atomgroup.universe.trajectory.totaltime
         metadata['dt'] = self._trajectory.dt
         metadata['time_unit'] = mda.core.flags['time_unit']

--- a/pmda/density.py
+++ b/pmda/density.py
@@ -251,7 +251,6 @@ class DensityAnalysis(ParallelAnalysisBase):
         self._ydim = ydim
         self._zdim = zdim
         self._trajectory = u.trajectory
-        self._n_frames = u.trajectory.n_frames
         if updating and atomselection is None:
             raise ValueError("updating=True requires a atomselection string")
         elif not updating and atomselection is not None:
@@ -300,12 +299,12 @@ class DensityAnalysis(ParallelAnalysisBase):
 
     def _conclude(self):
         self._grid = self._results[:].sum(axis=0)
-        self._grid /= float(self._n_frames)
+        self._grid /= float(self.n_frames)
         metadata = self._metadata if self._metadata is not None else {}
         metadata['psf'] = self._atomgroup.universe.filename
         metadata['dcd'] = self._trajectory.filename
         metadata['atomselection'] = self._atomselection
-        metadata['n_frames'] = self._n_frames
+        # metadata['n_frames'] = self._n_frames
         metadata['totaltime'] = self._atomgroup.universe.trajectory.totaltime
         metadata['dt'] = self._trajectory.dt
         metadata['time_unit'] = mda.core.flags['time_unit']

--- a/pmda/parallel.py
+++ b/pmda/parallel.py
@@ -352,6 +352,8 @@ class ParallelAnalysisBase(object):
                                                                  stop, step)
         n_frames = len(range(start, stop, step))
 
+        self.n_frames = n_frames
+
         if n_frames == 0:
             warnings.warn("run() analyses no frames: check start/stop/step")
         if n_frames < n_blocks:

--- a/pmda/rms/rmsf.py
+++ b/pmda/rms/rmsf.py
@@ -193,10 +193,9 @@ class RMSF(ParallelAnalysisBase):
         # serial case
         if n_blocks == 1:
             # get length of trajectory slice
-            k = len(self._blocks[0])
             self.mean = self._results[0, 0]
             self.sumsquares = self._results[0, 1]
-            self.rmsf = np.sqrt(self.sumsquares.sum(axis=1) / k)
+            self.rmsf = np.sqrt(self.sumsquares.sum(axis=1) / self.n_frames)
         # parallel case
         else:
             mean = self._results[:, 0]
@@ -207,10 +206,9 @@ class RMSF(ParallelAnalysisBase):
                 vals.append((len(self._blocks[i]), mean[i], sos[i]))
             # combine block results using fold method
             results = fold_second_order_moments(vals)
-            self.totalts = results[0]
             self.mean = results[1]
             self.sumsquares = results[2]
-            self.rmsf = np.sqrt(self.sumsquares.sum(axis=1) / self.totalts)
+            self.rmsf = np.sqrt(self.sumsquares.sum(axis=1) / self.n_frames)
             self._negative_rmsf(self.rmsf)
 
     @staticmethod

--- a/pmda/test/test_rmsf.py
+++ b/pmda/test/test_rmsf.py
@@ -32,7 +32,8 @@ def test_rmsf_accuracy(u, n_blocks, decimal, step):
                                   n_jobs=n_blocks)
     MDA_vals = mda.analysis.rms.RMSF(u.atoms).run(step=step)
     assert_almost_equal(MDA_vals.mean, PMDA_vals.mean, decimal=decimal)
-    assert_almost_equal(MDA_vals.sumsquares, PMDA_vals.sumsquares, decimal=decimal)
+    assert_almost_equal(MDA_vals.sumsquares, PMDA_vals.sumsquares,
+                        decimal=decimal)
     assert_almost_equal(MDA_vals.rmsf, PMDA_vals.rmsf, decimal=decimal)
 
 

--- a/pmda/test/test_rmsf.py
+++ b/pmda/test/test_rmsf.py
@@ -23,8 +23,21 @@ def u():
     return mda.Universe(PSF, DCD)
 
 
+@pytest.mark.parametrize('n_blocks', (2, 3, 4))
+@pytest.mark.parametrize('decimal', (7, 10, 11))
+@pytest.mark.parametrize("step", [1, 2, 3, 5])
+def test_rmsf_accuracy(u, n_blocks, decimal, step):
+    PMDA_vals = RMSF(u.atoms).run(step=step,
+                                  n_blocks=n_blocks,
+                                  n_jobs=n_blocks)
+    MDA_vals = mda.analysis.rms.RMSF(u.atoms).run(step=step)
+    assert_almost_equal(MDA_vals.mean, PMDA_vals.mean, decimal=decimal)
+    assert_almost_equal(MDA_vals.sumsquares, PMDA_vals.sumsquares, decimal=decimal)
+    assert_almost_equal(MDA_vals.rmsf, PMDA_vals.rmsf, decimal=decimal)
+
+
 @pytest.mark.parametrize('n_blocks', (1, 2, 3, 4, 5, 10))
-@pytest.mark.parametrize('n_frames', (10, 50, 100))
+@pytest.mark.parametrize('n_frames', (10, 45, 90))
 def test_RMSF_values(u, n_blocks, n_frames):
     PMDA_vals = RMSF(u.atoms).run(stop=n_frames,
                                   n_blocks=n_blocks,
@@ -49,3 +62,11 @@ def test_RMSF_n_jobs(u, n_blocks):
 def test_negative_RMSF_raises_ValueError():
     with pytest.raises(ValueError):
         RMSF._negative_rmsf(np.array([-1, -1, -1]))
+
+
+@pytest.mark.parametrize("stop", [10, 33, 45, 90])
+@pytest.mark.parametrize("step", [1, 2, 3, 5])
+def test_n_frames(u, stop, step):
+    F = RMSF(u.atoms)
+    F.run(stop=stop, step=step)
+    assert F.n_frames == len(range(0, stop, step))


### PR DESCRIPTION
Fixes #108 

Changes:
 - Added self.n_frames to parallel.py
 - Updated DensityAnalysis conclude() to read self.n_frames instead of trajectory length
 - Updated RMSF to read self.n_frames in _conclude()
 - Added test_n_frames() to both DensityAnalysis and RMSF tests
 - Added test_accuracy() to test_rmsf.py to verify sub-selecting trajectories doesn't affect accuracy
 - Added new data files to test_density.py to use for testing time step sub-selections
 - Consolidated two tests in test_density.py into one test that verifies both the array values and the sum of their values for different trajectory lengths, blocks, and step sizes


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
