### PR TITLE
modify the names of schedulers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,7 +13,18 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-2019/10/14 VOD555, nawtrey
+MM/DD/YYYY VOD555
+
+  * 0.3.1  
+
+Fixes
+  * use the new dask scheduler names (#102)
+    - multiprocessing --> processes
+    - single-threaded --> synchronous
+    - threaded --> threads
+  
+
+10/14/2019 VOD555, nawtrey
 
   * 0.3.0
 
@@ -34,7 +45,7 @@ Changes
   * Moved RMSF and RMSD into pmda.rms module
 
 
-2019/05/23 VOD555
+05/23/2019 VOD555
 
   * 0.2.1
 
@@ -42,7 +53,7 @@ Enhancements (internal)
   * add timer for the time to start the workers
 
 
-11/02/18 VOD555, richardjgowers, mimischi, iparask, orbeckst, kain88-de
+11/02/2018 VOD555, richardjgowers, mimischi, iparask, orbeckst, kain88-de
 
   * 0.2.0
 
@@ -69,7 +80,7 @@ Changes
   * dask.distributed is now a dependency
 
 
-06/07/18 orbeckst
+06/07/2018 orbeckst
 
   * 0.1.1
 
@@ -78,7 +89,7 @@ Fixes
     this release is pip-installable (Issue #42)
 
 
-05/11/18 kain88-de, orbeckst
+05/11/2018 kain88-de, orbeckst
 
   * 0.1.0
 

--- a/conftest.py
+++ b/conftest.py
@@ -26,8 +26,8 @@ def client(tmpdir_factory, request):
 
 
 @pytest.fixture(scope='session', params=('distributed',
-                                         'multiprocessing',
-                                         'single-threaded'))
+                                         'processes',
+                                         'synchronous'))
 def scheduler(request, client):
     if request.param == 'distributed':
         arg = client

--- a/docs/userguide/parallelization.rst
+++ b/docs/userguide/parallelization.rst
@@ -103,7 +103,7 @@ In this way one can spread an analysis task over many different nodes.
 	      *distributed* scheduler, the synchronous scheduler is
 	      automatically used. Alternatively, set the synchronous
         scheduler with
-
+        
 	      .. code:: python
 
 	         dask.config.set(scheduler='synchronous')

--- a/docs/userguide/parallelization.rst
+++ b/docs/userguide/parallelization.rst
@@ -18,17 +18,17 @@ By default, all the available cores on the local machine (laptop or
 workstation) are used with the ``n_jobs=-1`` keyword but any number
 can be set, e.g., ``n_jobs=4`` to split the trajectory into 4 blocks.
 
-Internally, this uses the multiprocessing `scheduler`_ of dask. If you
-want to make use of more advanced scheduler features or scale your
-analysis to multiple nodes, e.g., in an HPC (high performance
-computing) environment, then use the :mod:`distributed` scheduler, as
-described next. If ``n_jobs==1`` a single threaded scheduler is used
-[#threads]_.
+Internally, this uses the processes (multiprocessing) `scheduler`_
+of dask. If you want to make use of more advanced scheduler features
+or scale your analysis to multiple nodes, e.g., in an HPC (high
+performance computing) environment, then use the :mod:`distributed`
+scheduler, as described next. If ``n_jobs==1`` a synchronous
+(single threaded) scheduler is used [#threads]_.
 
 .. _`scheduler`:
    https://docs.dask.org/en/latest/scheduler-overview.html
 
-     
+
 ``dask.distributed``
 ====================
 
@@ -51,7 +51,7 @@ Local cluster (single machine)
 ------------------------------
 
 You can try out `dask.distributed`_ with a `local cluster`_, which
-sets up a scheduler and workers on the local machine. 
+sets up a scheduler and workers on the local machine.
 
 .. code:: python
 
@@ -62,10 +62,10 @@ sets up a scheduler and workers on the local machine.
 Setting up the ``client`` is sufficient for Dask_ (and PMDA, namely the
 :meth:`~pmda.parallel.ParallelAnalysisBase.run` method) to use it. We
 continue to use the :ref:`RMSD example<example-parallel-rmsd>`:
-      
+
 .. code:: python
 
-   rmsd_ana = rms.RMSD(u.atoms, ref.atoms).run()	  
+   rmsd_ana = rms.RMSD(u.atoms, ref.atoms).run()
 
 Because the local cluster contains 8 workers, the RMSD trajectory
 analysis will be parallelized over 8 trajectory segments.
@@ -85,11 +85,11 @@ would initialize the `distributed.Client`_ and this is enough to use
 .. code:: python
 
    import distributed
-   client = distributed.Client('192.168.0.1:8786')   
-   rmsd_ana = rms.RMSD(u.atoms, ref.atoms).run()	  
+   client = distributed.Client('192.168.0.1:8786')
+   rmsd_ana = rms.RMSD(u.atoms, ref.atoms).run()
 
 In this way one can spread an analysis task over many different nodes.
-   
+
 .. _`local cluster`:
    https://distributed.readthedocs.io/en/latest/local-cluster.html
 .. _`distributed.Client`:
@@ -98,17 +98,17 @@ In this way one can spread an analysis task over many different nodes.
    https://docs.dask.org/en/latest/scheduling.html#configuration
 
 .. rubric:: Footnotes
-.. [#threads] The *single-threaded* scheduler is very useful for
+.. [#threads] The *synchronous* scheduler is very useful for
 	      debugging_. By setting ``n_jobs=1`` and not using a
-	      *distributed* scheduler, the single threaded scheduler is
-	      automatically used. Alternatively, set the single
-	      threaded scheduler with
+	      *distributed* scheduler, the synchronous scheduler is
+	      automatically used. Alternatively, set the synchronous
+        scheduler with
 
 	      .. code:: python
 
-	         dask.config.set(scheduler='single-threaded')
+	         dask.config.set(scheduler='synchronous')
 
 	      for any ``n_jobs``.
-	      
+
 .. _debugging:
-   https://docs.dask.org/en/latest/debugging.html#use-the-single-threaded-scheduler
+   https://docs.dask.org/en/latest/scheduling.html#single-thread

--- a/docs/userguide/parallelization.rst
+++ b/docs/userguide/parallelization.rst
@@ -98,12 +98,11 @@ In this way one can spread an analysis task over many different nodes.
    https://docs.dask.org/en/latest/scheduling.html#configuration
 
 .. rubric:: Footnotes
-.. [#threads] The *synchronous* scheduler is very useful for
-	      debugging_. By setting ``n_jobs=1`` and not using a
-	      *distributed* scheduler, the synchronous scheduler is
-	      automatically used. Alternatively, set the synchronous
-        scheduler with
-        
+.. [#threads] The *synchronous* scheduler is very useful for debugging_.
+        By setting ``n_jobs=1`` and not using a *distributed* scheduler,
+        the synchronous scheduler is automatically used. Alternatively,
+        set the synchronous scheduler with
+
 	      .. code:: python
 
 	         dask.config.set(scheduler='synchronous')
@@ -111,4 +110,4 @@ In this way one can spread an analysis task over many different nodes.
 	      for any ``n_jobs``.
 
 .. _debugging:
-   https://docs.dask.org/en/latest/scheduling.html#single-thread
+   https://docs.dask.org/en/latest/debugging.html

--- a/pmda/parallel.py
+++ b/pmda/parallel.py
@@ -326,14 +326,14 @@ class ParallelAnalysisBase(object):
         # job. Therefore we run this on the single threaded scheduler for
         # debugging.
         if scheduler is None and n_jobs == 1:
-            scheduler = 'single-threaded'
+            scheduler = 'synchronous'
 
         # fall back to multiprocessing, we tried everything
         if scheduler is None:
-            scheduler = 'multiprocessing'
+            scheduler = 'processes'
 
         if n_blocks is None:
-            if scheduler == 'multiprocessing':
+            if scheduler == 'processes':
                 n_blocks = n_jobs
             elif isinstance(scheduler, dask.distributed.Client):
                 n_blocks = len(scheduler.ncores())
@@ -345,7 +345,7 @@ class ParallelAnalysisBase(object):
                     "Please provide `n_blocks` in call to method.")
 
         scheduler_kwargs = {'scheduler': scheduler}
-        if scheduler == 'multiprocessing':
+        if scheduler == 'processes':
             scheduler_kwargs['num_workers'] = n_jobs
 
         start, stop, step = self._trajectory.check_slice_indices(start,

--- a/pmda/test/test_parallel.py
+++ b/pmda/test/test_parallel.py
@@ -117,7 +117,7 @@ def test_nblocks(analysis, n_blocks):
 
 
 def test_guess_nblocks(analysis):
-    with dask.config.set(scheduler='multiprocessing'):
+    with dask.config.set(scheduler='processes'):
         analysis.run(n_jobs=-1)
     assert len(analysis._results) == joblib.cpu_count()
 


### PR DESCRIPTION
Fixes #102 

Changes made in this Pull Request:
 - Modify the names of schedulers:
    multiporcessing --> processes
    single-threaded --> synchronous
    threaded --> threads


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
