### PR TITLE
upgrade to MDAnalysis 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   global:
     - secure: "ifPjMMIP4eV58IF3//zrPpN8hYPrcT9Sfq953yX3Wu3ObQ0r3y7qHCMBwRLqf14SYDSf4siYPm+GTkKW9Gb4jIZzmOJPFOgSJJx6MjtaS+kbzG3uNGpjqOVz9RfGzXlZM1cNkuPZjofq2pBOIIqrE7psWUJiOfDtAkTa+BGMl6Oc8pBCVtVQt0XT1xkg1nejjNNuRvuKnLCyx40SMReDU68ai4Q0PFmIkbf6duMd8zWfR9ITZJYQETRmZn85KiyW0Ax6W9dQgK0O6n3ucId3QIQ5Iim3MyLzp/d/KeLBnO/i3spTvGrlyPGQLKk78nVjZRVaqKaubJpAXWgCGHOF51LRVvdFc73TTvivu0GPiY0FlyKOsY+MHE13+RJHsLXa9aueO0NUw4/2WjwtCkV2LYHJRszc8VbyD6b8mgJwc6lchaptmNknn9TvlCTNzI3GS7QVuhZJzNGkCvH86IMdMf9NyxeNBEW0HyAbST8LTArbqMtBZlU5HwxhI50JcdmKhudZCZs2k/YipWp8PIz3R+gmSHRtwseV7paM0Np12Q9+xvIYNKto9+frGlPDChP4wTdSpJBN7fY5bcwHrN6v/AFPIHXSIne+8UvKrjlNa8ZFaCMWC8Yc+GBwjCe+dhbV4+UtuDoC1ABgyY3haFXMu8mtWslzbwozzw0W30OFYWg="    
     # Set default python version to avoid repetition later
-    - PYTHON_VERSION=3.6
+    - PYTHON_VERSION=3.7
     - MAIN_CMD="pytest"
     - SETUP_CMD="pmda --pep8 --cov pmda"
     # mdanalysis develop from source (see below), which needs
@@ -40,8 +40,9 @@ env:
 
 
   matrix:
+    - PYTHON=3.8 CODECOV=true
+    - PYTHON=3.7 CODECOV=true
     - PYTHON=3.6 CODECOV=true
-    - PYTHON=3.5 CODECOV=true
     - PYTHON=2.7 CODECOV=true
     - NAME='lint' MAIN_CMD='pylint pmda' BUILD_CMD='' SETUP_CMD=''
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-MM/DD/YYYY VOD555
+MM/DD/YYYY VOD555, orbeckst
 
   * 0.4.0
 
@@ -26,6 +26,10 @@ Fixes
     - single-threaded --> synchronous
     - threaded --> threads
   * fixed RDF functions (gave wrong results if step != 1) (#114)
+
+Changes
+  * requires MDAnalysis >= 1.0.0 (#122)
+  * dropped official support for Python 3.5 (2.7 and >= 3.6 are supported)
 
 
 10/14/2019 VOD555, nawtrey

--- a/pmda/rms/rmsd.py
+++ b/pmda/rms/rmsd.py
@@ -14,19 +14,14 @@ Calculating Root-Mean-Square Deviations (RMSD) --- :mod:`pmda.rms`
 This module contains parallel versions of analysis tasks in
 :mod:`MDAnalysis.analysis.rms.RMSD`.
 
-.. autoclass:: RMSD
-    :members:
-
-    .. attribute:: rmsd
-
-        Contains the time series of the RMSD as a `Tx3` :class:`numpy.ndarray`
-        array with content ``[[frame, time (ps), RMSD (Å)], [...], ...]``,
-        where `T` is the number of time steps selected in the :meth:`run`
-        method.
-
 See Also
 --------
-MDAnalysis.analysis.rms.RMSD
+:mod:`MDAnalysis.analysis.rms`
+
+
+.. autoclass:: RMSD
+    :members:
+    :inherited-members:
 
 """
 from __future__ import absolute_import
@@ -51,9 +46,10 @@ class RMSD(ParallelAnalysisBase):
     Attributes
     ----------
     rmsd : array
-         `Tx3` array where each row contains
-         `[frame, time (ps), RMSD (Å)]`, and `T` is the number of time steps
-         selected in the :meth:`run` method.
+          Contains the time series of the RMSD as a `Tx3`
+          :class:`numpy.ndarray` array with content ``[[frame, time
+          (ps), RMSD (Å)], [...], ...]``, where `T` is the number of
+          time steps selected in the :meth:`run` method.
 
     Parameters
     ----------

--- a/pmda/rms/rmsf.py
+++ b/pmda/rms/rmsf.py
@@ -16,11 +16,8 @@ This module contains parallel versions of analysis tasks in
 
 .. autoclass:: RMSF
     :members:
+    :inherited-members:
 
-    .. attribute:: rmsf
-
-        Results are stored in this N-length :class:`numpy.ndarray` array,
-        giving RMSFs for each of the given atoms.
 
 See Also
 --------
@@ -45,9 +42,9 @@ class RMSF(ParallelAnalysisBase):
     Attributes
     ----------
     rmsf : array
-         N-length :class:`numpy.ndarray` array of RMSF values, where `N` is
-         the number of atoms in the atomgroup of interest. Returned values
-         have units of ångströms.
+         ``N``-length :class:`numpy.ndarray` array of RMSF values,
+         where ``N`` is the number of atoms in the `atomgroup` of
+         interest. Returned values have units of ångströms.
 
     Parameters
     ----------

--- a/pmda/test/test_density.py
+++ b/pmda/test/test_density.py
@@ -2,7 +2,7 @@ import pytest
 import MDAnalysis as mda
 import numpy as np
 from pmda.density import DensityAnalysis
-from MDAnalysis.analysis.density import density_from_Universe
+from MDAnalysis.analysis import density as serial_density
 from numpy.testing import assert_almost_equal
 from MDAnalysisTests.datafiles import GRO_MEMPROT, XTC_MEMPROT
 from MDAnalysisTests.datafiles import PSF_TRICLINIC, DCD_TRICLINIC
@@ -26,11 +26,11 @@ def test_density_values(u1, n_blocks, stop, step):
                                updating=True)
     parallel.run(n_blocks=n_blocks, n_jobs=n_blocks, start=0, stop=stop,
                  step=step)
-    serial = density_from_Universe(u1, atomselection='name OD1',
-                                   update_selection=True, start=0, stop=stop,
-                                   step=step)
-    assert np.sum(serial.grid) == np.sum(parallel.density.grid)
-    assert_almost_equal(serial.grid, parallel.density.grid, decimal=17)
+    ag = u1.select_atoms('name OD1', updating=True)
+    serial = serial_density.DensityAnalysis(ag).run(
+        start=0, stop=stop, step=step)
+    assert np.sum(serial.density.grid) == np.sum(parallel.density.grid)
+    assert_almost_equal(serial.density.grid, parallel.density.grid, decimal=16)
 
 
 def test_updating(u1):
@@ -48,12 +48,13 @@ def test_gridcenter(u1):
     xdim = 190
     ydim = 200
     zdim = 210
-    serial = density_from_Universe(u1, atomselection='name OD1',
-                                   update_selection=True,
-                                   gridcenter=gridcenter,
-                                   xdim=xdim,
-                                   ydim=ydim,
-                                   zdim=zdim)
+    ag = u1.select_atoms('name OD1', updating=True)
+    serial = serial_density.DensityAnalysis(
+        ag,
+        gridcenter=gridcenter,
+        xdim=xdim,
+        ydim=ydim,
+        zdim=zdim).run()
     parallel = DensityAnalysis(u1.atoms, atomselection='name OD1',
                                updating=True,
                                gridcenter=gridcenter,
@@ -62,7 +63,7 @@ def test_gridcenter(u1):
                                zdim=zdim)
     core_number = 4
     parallel.run(n_blocks=core_number, n_jobs=core_number)
-    assert_almost_equal(serial.grid, parallel.density.grid)
+    assert_almost_equal(serial.density.grid, parallel.density.grid)
     assert_almost_equal(parallel._gridcenter, gridcenter)
     assert len(parallel.density.edges[0]) == xdim + 1
     assert len(parallel.density.edges[1]) == ydim + 1

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,9 @@ setup(
                  'Programming Language :: Python :: 2',
                  'Programming Language :: Python :: 2.7',
                  'Programming Language :: Python :: 3',
-                 'Programming Language :: Python :: 3.4',
-                 'Programming Language :: Python :: 3.5',
                  'Programming Language :: Python :: 3.6',
+                 'Programming Language :: Python :: 3.7',
+                 'Programming Language :: Python :: 3.8',
     ],
     project_urls={
         'Documentation': 'https://www.mdanalysis.org/pmda/',
@@ -48,7 +48,7 @@ setup(
     },
     packages=find_packages(),
     install_requires=[
-        'MDAnalysis>=0.19.0',
+        'MDAnalysis>=1.0.0',
         'dask>=0.18',
         'distributed',
         'six',
@@ -58,5 +58,5 @@ setup(
     ],
     tests_require=[
         'pytest',
-        'MDAnalysisTests>=0.19.0',  # keep
+        'MDAnalysisTests>=1.0.0',  # keep
     ], )


### PR DESCRIPTION
Fixes #122 

Changes made in this Pull Request:
 - upgrade to MDAnalysis 1.0.0
 - support Python 2.7, 3.6-3.8 and dropped 3.5
 - use new serial DensityAnalysis for comparison in tests


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
