### PR TITLE
Add test and fix for uneven blocks

### DIFF
--- a/pmda/contacts.py
+++ b/pmda/contacts.py
@@ -286,7 +286,7 @@ class Contacts(ParallelAnalysisBase):
         return y
 
     def _conclude(self):
-        self.timeseries = np.hstack(self._results)
+        self.timeseries = np.concatenate(self._results)
 
 
 def q1q2(atomgroup, radius=4.5):

--- a/pmda/parallel.py
+++ b/pmda/parallel.py
@@ -153,7 +153,7 @@ class ParallelAnalysisBase(object):
                # for each frame are stored in ``self._results`` in a per block
                # basis. Here those results should be moved and reshaped into a
                # sensible new variable.
-               self.results = np.hstack(self._results)
+               self.results = np.concatenate(self._results)
                # Apply normalisation and averaging to results here if wanted.
                self.results /= np.sum(self.results
 

--- a/pmda/test/test_contacts.py
+++ b/pmda/test/test_contacts.py
@@ -63,12 +63,13 @@ class TestContacts(object):
                       start=None,
                       step=None,
                       stop=None,
+                      n_blocks=1,
                       **kwargs):
         acidic = universe.select_atoms(self.sel_acidic)
         basic = universe.select_atoms(self.sel_basic)
         return contacts.Contacts(
             (acidic, basic), (acidic, basic), radius=6.0, **kwargs).run(
-                start=start, stop=stop, step=step)
+                start=start, stop=stop, step=step, n_blocks=n_blocks)
 
     def test_startframe(self, universe):
         """test_startframe: TestContactAnalysis1: start frame set to 0 (resolution of
@@ -76,6 +77,11 @@ class TestContacts(object):
 
         """
         CA1 = self._run_Contacts(universe)
+        assert len(CA1.timeseries) == universe.trajectory.n_frames
+
+    def test_uneven_blocks(self, universe):
+        """ Issue #140"""
+        CA1 = self._run_Contacts(universe, n_blocks=3)
         assert len(CA1.timeseries) == universe.trajectory.n_frames
 
     def test_end_zero(self, universe):

--- a/pmda/test/test_custom.py
+++ b/pmda/test/test_custom.py
@@ -35,6 +35,10 @@ def custom_function_tensor(ag):
     return ag.moment_of_inertia()
 
 
+def custom_function_scalar_tensor(ag):
+    return [ag.radius_of_gyration(), ag.moment_of_inertia()]
+
+
 @pytest.mark.parametrize('custom_function', [
     custom_function_vector,
     custom_function_scalar,
@@ -55,6 +59,28 @@ def test_AnalysisFromFunction(scheduler, universe, custom_function, step):
     results = []
     for ts in universe.trajectory[::step]:
         results.append(custom_function(universe.atoms))
+    results = np.asarray(results)
+
+    for ana in (ana1, ana2, ana3):
+        assert_equal(results, ana.results)
+
+
+@pytest.mark.parametrize('n_blocks', [1, 3])
+def test_different_blocks(scheduler, universe, n_blocks):
+    #  This test will fail with np.hstack() #PR 88
+    ana1 = custom.AnalysisFromFunction(
+        custom_function_tensor, universe, universe.atoms).run(
+        n_blocks=n_blocks)
+    ana2 = custom.AnalysisFromFunction(
+        custom_function_tensor, universe, universe.atoms).run(
+        n_blocks=n_blocks)
+    ana3 = custom.AnalysisFromFunction(
+        custom_function_tensor, universe, universe.atoms).run(
+        n_blocks=n_blocks)
+
+    results = []
+    for ts in universe.trajectory:
+        results.append(custom_function_tensor(universe.atoms))
     results = np.asarray(results)
 
     for ana in (ana1, ana2, ana3):

--- a/pmda/test/test_parallel.py
+++ b/pmda/test/test_parallel.py
@@ -56,7 +56,7 @@ class NoneAnalysis(parallel.ParallelAnalysisBase):
         pass
 
     def _conclude(self):
-        self.res = np.hstack(self._results)
+        self.res = np.concatenate(self._results)
 
     def _single_frame(self, ts, atomgroups):
         return ts.frame

--- a/pmda/test/test_rmsd.py
+++ b/pmda/test/test_rmsd.py
@@ -50,3 +50,10 @@ class TestRMSD(object):
         assert_almost_equal(RMSD1.rmsd, correct_values_frame_5, 4,
                             err_msg="error: rmsd profile should match " +
                             "test values")
+
+    @pytest.mark.parametrize('n_blocks', [1, 2, 3])
+    def test_rmsd_different_blocks(self, universe, n_blocks):
+        ca = universe.select_atoms("name CA")
+        universe.trajectory.rewind()
+        RMSD1 = RMSD(ca, ca).run(n_blocks=n_blocks)
+        assert_array_equal(RMSD1.rmsd.shape, (universe.trajectory.n_frames, 3))


### PR DESCRIPTION
Fixes #140

Changes made in this Pull Request:
 - change `np.hstack` to `np.concatenate` in all `_conclude` code
 - add tests for uneven blocks.


PR Checklist
------------
 - [x] Tests?
 - [] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
