### PR TITLE
Fix handling results array for multiple blocks. 

### DIFF
--- a/pmda/parallel.py
+++ b/pmda/parallel.py
@@ -396,7 +396,7 @@ class ParallelAnalysisBase(object):
                 res = [([], [], [], 0, wait_start, 0, 0)]
             # record conclude time
             with timeit() as conclude:
-                self._results = np.asarray([el[0] for el in res])
+                self._results = [el[0] for el in res]
                 # save the frame numbers for all blocks
                 self._blocks = _blocks
                 self._conclude()


### PR DESCRIPTION
_conclude should be the function reshaping and handling the data, not run.

Fixes #

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
